### PR TITLE
Temporary fix for 4.17 until RMC v3 is ready

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshComponent.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshComponent.cpp
@@ -6,6 +6,7 @@
 #include "RuntimeMeshGenericVertex.h"
 #include "RuntimeMeshVersion.h"
 #include "PhysicsEngine/PhysicsSettings.h"
+#include "Physics/IPhysXCookingModule.h"
 
 
 /** Runtime mesh scene proxy */
@@ -1778,12 +1779,12 @@ void URuntimeMeshComponent::UpdateCollision()
 	BodySetup->BodySetupGuid = FGuid::NewGuid();
 
 
-#if WITH_RUNTIME_PHYSICS_COOKING || WITH_EDITOR
-	// Clear current mesh data
-	BodySetup->InvalidatePhysicsData();
-	// Create new mesh data
-	BodySetup->CreatePhysicsMeshes();
-#endif // WITH_RUNTIME_PHYSICS_COOKING || WITH_EDITOR
+	if (FModuleManager::Get().IsModuleLoaded(FName("RuntimePhysXCooking")))
+	{
+		BodySetup->InvalidatePhysicsData();
+		// Create new mesh data
+		BodySetup->CreatePhysicsMeshes();
+	}
 
 	// Recreate physics state if necessary
 	if (NeedsNewPhysicsState)

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshCore.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshCore.h
@@ -338,6 +338,8 @@ struct RUNTIMEMESHCOMPONENT_API FRuntimeMeshVertexTypeInfo
 
 	FRuntimeMeshVertexTypeInfo(FString Name, FGuid Guid) : TypeName(Name), TypeGuid(Guid) { }
 
+	virtual ~FRuntimeMeshVertexTypeInfo() {}
+
 	virtual bool Equals(const FRuntimeMeshVertexTypeInfo* Other) const
 	{
 		return TypeGuid == Other->TypeGuid;

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshGenericVertex.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshGenericVertex.h
@@ -534,6 +534,8 @@ struct FRuntimeMeshVertexTypeInfo_GenericVertex : public FRuntimeMeshVertexTypeI
 			FString::Printf(TEXT("RuntimeMeshVertex<%d, %d, %d, %d, %d, %d, %d>"), WantsPosition, WantsNormal, WantsTangent, WantsColor, NumWantedUVChannels, (int32)NormalTangentType, (int32)UVType),
 			GetVertexGuid(VertexName)) { }
 
+	virtual ~FRuntimeMeshVertexTypeInfo_GenericVertex() { }
+
 	static FGuid GetVertexGuid(FString VertexName)
 	{
 		uint32 TypeID = 0;

--- a/Source/RuntimeMeshComponent/RuntimeMeshComponent.Build.cs
+++ b/Source/RuntimeMeshComponent/RuntimeMeshComponent.Build.cs
@@ -4,7 +4,7 @@ using UnrealBuildTool;
 
 public class RuntimeMeshComponent : ModuleRules
 {
-	public RuntimeMeshComponent(TargetInfo Target)
+	public RuntimeMeshComponent(ReadOnlyTargetRules rules): base(rules)
 	{
         PrivateIncludePaths.Add("RuntimeMeshComponent/Private");
         PublicIncludePaths.Add("RuntimeMeshComponent/Public");

--- a/Source/RuntimeMeshComponentEditor/RuntimeMeshComponentEditor.Build.cs
+++ b/Source/RuntimeMeshComponentEditor/RuntimeMeshComponentEditor.Build.cs
@@ -4,7 +4,7 @@ namespace UnrealBuildTool.Rules
 {
 	public class RuntimeMeshComponentEditor : ModuleRules
 	{
-        public RuntimeMeshComponentEditor(TargetInfo Target)
+        public RuntimeMeshComponentEditor(ReadOnlyTargetRules rules): base(rules)
 		{
 			PrivateIncludePaths.Add("RuntimeMeshComponentEditor/Private");
             PublicIncludePaths.Add("RuntimeMeshComponentEditor/Public");


### PR DESCRIPTION
When compling plugin under 4.17 it shows the following errors/warnings:
1) Need to add virtual destructors to some RMC classes to avoid potential memory leaks
2) Need to use ReadOnlyTargetRules in .cs files since 4.16
3) Preprocessor directive `#WITH_RUNTIME_PHYSICS_COOKING` was removed. Epic implemeted 
RUNTIME PHYSICS_COOKNIG as so the proper way now is to use `FModuleManager::Get().IsModuleLoaded(FName("RuntimePhysXCooking"))`