### PR TITLE
DetailBuilder.GetDetailsView() returns a pointer, rather than a refer…

### DIFF
--- a/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentDetails.cpp
+++ b/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentDetails.cpp
@@ -25,7 +25,7 @@ void FRuntimeMeshComponentDetails::CustomizeDetails( IDetailLayoutBuilder& Detai
 	const FText ConvertToStaticMeshText = LOCTEXT("ConvertToStaticMesh", "Create StaticMesh");
 
 	// Cache set of selected things
-	SelectedObjectsList = DetailBuilder.GetDetailsView().GetSelectedObjects();
+	SelectedObjectsList = DetailBuilder.GetDetailsView()->GetSelectedObjects();
 
 	RuntimeMeshCategory.AddCustomRow(ConvertToStaticMeshText, false)
 	.NameContent()


### PR DESCRIPTION
In the current build of UE (4.18) it appears they have changed the return type of GetDetailsView() to return a pointer instead of a reference. A simple replacement of . to -> but enough to prevent compilation in newer UnrealEngine builds.

( My first ever pull request, hope I got this right. And thanks for an amazing component. )