### PR TITLE
Fixed Clang warnings & errors

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -61,13 +61,13 @@ UWorld* FRuntimeMeshCollisionCookTickObject::GetTickableGameObjectWorld() const
 
 URuntimeMesh::URuntimeMesh(const FObjectInitializer& ObjectInitializer)
 	: UObject(ObjectInitializer)
+	, Data(new FRuntimeMeshData())
+	, bCollisionIsDirty(false)
 	, bUseComplexAsSimpleCollision(true)
 	, bUseAsyncCooking(false)
 	, bShouldSerializeMeshData(true)
-	, bCollisionIsDirty(false)
 	, CollisionMode(ERuntimeMeshCollisionCookingMode::CookingPerformance)
 	, BodySetup(nullptr)
-	, Data(new FRuntimeMeshData())
 {
 	Data->Setup(TWeakObjectPtr<URuntimeMesh>(this));
 }

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshBuilder.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshBuilder.cpp
@@ -31,7 +31,7 @@ FRuntimeMeshVerticesAccessor::FRuntimeMeshVerticesAccessor(TArray<uint8>* Positi
 	, bIsReadonly(bInIsReadonly)
 	, PositionStream(PositionStreamData)
 	, TangentStream(TangentStreamData), bTangentHighPrecision(false), TangentSize(0), TangentStride(0)
-	, UVStream(UVStreamData), bUVHighPrecision(false), UVSize(0), UVStride(0), UVChannelCount(0)
+	, UVStream(UVStreamData), bUVHighPrecision(false), UVChannelCount(0), UVSize(0), UVStride(0)
 	, ColorStream(ColorStreamData)
 {
 }
@@ -42,7 +42,7 @@ FRuntimeMeshVerticesAccessor::FRuntimeMeshVerticesAccessor(bool bInTangentsHighP
 	, bIsReadonly(bInIsReadonly)
 	, PositionStream(PositionStreamData)
 	, TangentStream(TangentStreamData), bTangentHighPrecision(false), TangentSize(0), TangentStride(0)
-	, UVStream(UVStreamData), bUVHighPrecision(false), UVSize(0), UVStride(0), UVChannelCount(0)
+	, UVStream(UVStreamData), bUVHighPrecision(false), UVChannelCount(0), UVSize(0), UVStride(0)
 	, ColorStream(ColorStreamData)
 {
 	Initialize(bInTangentsHighPrecision, bInUVsHighPrecision, bInUVCount);

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.cpp
@@ -71,7 +71,7 @@ void FRuntimeMeshVertexBuffer::SetData(const TArray<uint8>& Data)
 
 
 FRuntimeMeshIndexBuffer::FRuntimeMeshIndexBuffer()
-	: IndexSize(-1), NumIndices(0), UsageFlags(EBufferUsageFlags::BUF_None)
+	: NumIndices(0), IndexSize(-1), UsageFlags(EBufferUsageFlags::BUF_None)
 {
 }
 

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshBlueprint.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshBlueprint.h
@@ -40,8 +40,8 @@ public:
 		: Position(0.0f, 0.0f, 0.0f)
 		, Normal(0.0f, 0.0f, 1.0f)
 		, Tangent(FVector(1.0f, 0.0f, 0.0f), false)
-		, UV0(0.0f, 0.0f)
 		, Color(255, 255, 255)
+		, UV0(0.0f, 0.0f)
 	{
 	}
 
@@ -49,8 +49,8 @@ public:
 		: Position(InPosition)
 		, Normal(InNormal)
 		, Tangent(InTangent)
-		, UV0(InUV0)
 		, Color(InColor)
+		, UV0(InUV0)
 	{
 	}
 };

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshData.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshData.h
@@ -1044,7 +1044,7 @@ private:
 
 
 	/* Creates an mesh section of a specified type at the specified index. */
-	template<typename TangentType, typename UVType>
+	template<typename TangentType, typename UVType, typename IndexType>
 	FRuntimeMeshSectionPtr CreateOrResetSection(int32 SectionId, EUpdateFrequency UpdateFrequency)
 	{
 		static_assert(FRuntimeMeshIndexTraits<IndexType>::IsValidIndexType, "Indices can only be of type uint16, uint32, or int32");

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshGenericVertex.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshGenericVertex.h
@@ -789,7 +789,7 @@ struct FRuntimeMeshDualUVHighPrecision
 template<typename VertexType>
 inline bool GetTangentIsHighPrecision()
 {
-	static_assert(false, "Invalid Tangent type.");
+	static_assert(sizeof(VertexType) == -1, "Invalid Tangent type.");
 }
 
 template<>
@@ -807,7 +807,7 @@ inline bool GetTangentIsHighPrecision<FRuntimeMeshTangentsHighPrecision>()
 template<typename VertexType>
 inline void GetUVVertexProperties(bool& bIsUsingHighPrecision, int32& NumUVs)
 {
-	static_assert(false, "Invalid UV type.");
+	static_assert(sizeof(VertexType) == -1, "Invalid UV type.");
 }
 
 template<>


### PR DESCRIPTION
Reordered member initializers in some constructors to actual initialization order, and modified some template usage to get rid of clang warnings/errors