### PR TITLE
Fixed clang errors

### DIFF
--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshBuilder.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshBuilder.h
@@ -99,11 +99,6 @@ private:
 		return Input;
 #endif
 	}
-	template<>
-	FVector4 ConvertPackedToNormal<FVector4>(const FVector4& Input)
-	{
-		return Input;
-	}
 
 	template<typename Type>
 	FVector ConvertPackedToTangent(const Type& Input)
@@ -113,11 +108,6 @@ private:
 #else
 		return Input;
 #endif
-	}
-	template<>
-	FVector ConvertPackedToTangent<FVector>(const FVector& Input)
-	{
-		return Input;
 	}
 
 	template<typename Type>
@@ -341,6 +331,18 @@ protected:
 	int32 AddSingleVertex();
 
 };
+
+// ISO C++ (IS 14.7.2/6) and Clang want template specializations to occur outside of the class scope
+template<>
+inline FVector4 FRuntimeMeshVerticesAccessor::ConvertPackedToNormal<FVector4>(const FVector4& Input)
+{
+	return Input;
+}
+template<>
+inline FVector FRuntimeMeshVerticesAccessor::ConvertPackedToTangent<FVector>(const FVector& Input)
+{
+	return Input;
+}
 
 class RUNTIMEMESHCOMPONENT_API FRuntimeMeshIndicesAccessor
 {

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshGenericVertex.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshGenericVertex.h
@@ -83,12 +83,12 @@ struct RuntimeMeshNormalUtil
 {
 	static void SetNormalW(FPackedNormal& Target, float Determinant)
 	{
-		Target.Vector.W = Determinant < 0.0f ? 0 : 255;
+		Target.Vector.W = Determinant < 0.0f ? 0 : -1; // -1 == 0xFF
 	}
 
 	static void SetNormalW(FPackedRGBA16N& Target, float Determinant)
 	{
-		Target.W = Determinant < 0.0f ? 0 : 65535;
+		Target.W = Determinant < 0.0f ? 0 : -1; // -1 == 0xFFFF
 	}
 };
 


### PR DESCRIPTION
Fixed clang errors caused by signed/unsigned mismatch, template specialization inside a class scope (which is apparently not allowed)