### PR TITLE
Kuldaen for high precison normals, use signed Vertex Element Type (VET_Short4N)

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.h
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.h
@@ -106,7 +106,11 @@ public:
 
 		if (bUseHighPrecision)
 		{
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 20
+			TangentElementType = VET_Short4N;
+#else
 			TangentElementType = VET_UShort4N;
+#endif
 			TangentSizeInBytes = sizeof(FRuntimeMeshTangentsHighPrecision);
 			TangentXOffset = offsetof(FRuntimeMeshTangentsHighPrecision, Tangent);
 			TangentZOffset = offsetof(FRuntimeMeshTangentsHighPrecision, Normal);


### PR DESCRIPTION
Similar to a previous fix, 4.20 needs to use the signed types for High Precision Normals