### PR TITLE
Fixed the delegate change in 4.21 by changing to BindUObject and addi…

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -184,7 +184,7 @@ void URuntimeMesh::SetBasicBodySetupParameters(UBodySetup* Setup)
 
 void URuntimeMesh::UpdateCollision(bool bForceCookNow)
 {
-#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 21
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 22
 	DoForAllLinkedComponents([bForceCookNow](URuntimeMeshComponent* Mesh)
 	{
 		Mesh->UpdateCollision(bForceCookNow);

--- a/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
+++ b/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
@@ -812,9 +812,9 @@ private:
 	virtual bool WantsNegXTriMesh() override { return false; }
 	//~ End Interface_CollisionDataProvider Interface
 
-#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 21
+#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 22
 	UBodySetup* CreateNewBodySetup();
-	void FinishPhysicsAsyncCook(UBodySetup* FinishedBodySetup);
+	void FinishPhysicsAsyncCook(bool bSuccess, UBodySetup* FinishedBodySetup);
 
 	void UpdateCollision(bool bForceCookNow);
 #endif


### PR DESCRIPTION
…ng bSuccess as required by the OnAsyncCollision handler. Updated the < 21 to <22 to allow build in 4.21.

Just letting you know I got the examples working in 4.21 using the above changes.

The examples crash when shift is pressed due to the slicer blueprint in the samples needing to be updated. 