### PR TITLE
Add velocity relevance

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.cpp
@@ -73,6 +73,9 @@ FPrimitiveViewRelevance FRuntimeMeshComponentSceneProxy::GetViewRelevance(const 
 	Result.bUsesLightingChannels = GetLightingChannelMask() != GetDefaultLightingChannelMask();
 	Result.bRenderCustomDepth = ShouldRenderCustomDepth();
 	MaterialRelevance.SetPrimitiveViewRelevance(Result);
+
+	Result.bVelocityRelevance = IsMovable() && Result.bOpaqueRelevance && Result.bRenderInMainPass;
+
 	return Result;
 }
 


### PR DESCRIPTION
Movable RMCs will show weird artifacts when TAA is enabled. I copied this line in from StaticMeshComponent to fix the issue.