### PR TITLE
fix: performance

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.cpp
@@ -93,7 +93,7 @@ void FRuntimeMeshIndexBuffer::InitRHI()
 	{
 		// Create the index buffer
 		FRHIResourceCreateInfo CreateInfo;
-		IndexBufferRHI = RHICreateIndexBuffer(IndexSize, GetBufferSize(), BUF_Dynamic, CreateInfo);
+		IndexBufferRHI = RHICreateIndexBuffer(IndexSize, GetBufferSize(), UsageFlags | BUF_ShaderResource, CreateInfo);
 	}
 }
 


### PR DESCRIPTION
the performance of RuntimeMeshComponent is worse than ProceduralMeshComponent in the same number of triangles.