### PR TITLE
Changes for 4.24

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -4,7 +4,7 @@
 #include "RuntimeMeshComponentPlugin.h"
 #include "PhysicsEngine/BodySetup.h"
 #include "PhysicsEngine/PhysicsSettings.h"
-#include "Physics/IPhysXCookingModule.h"
+#include "IPhysXCookingModule.h"
 #include "RuntimeMeshComponent.h"
 #include "RuntimeMeshProxy.h"
 #include "RuntimeMeshBuilder.h"

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshActor.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshActor.cpp
@@ -12,7 +12,7 @@ ARuntimeMeshActor::ARuntimeMeshActor(const FObjectInitializer& ObjectInitializer
 	, bRunGenerateMeshesOnConstruction(true)
 	, bRunGenerateMeshesOnBeginPlay(false)
 {
-	bCanBeDamaged = false;
+	SetCanBeDamaged(false);
 
 	RuntimeMeshComponent = CreateDefaultSubobject<URuntimeMeshComponent>(TEXT("RuntimeMeshComponent0"));
 	RuntimeMeshComponent->SetCollisionProfileName(UCollisionProfile::BlockAll_ProfileName);

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshActor.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshActor.cpp
@@ -12,7 +12,11 @@ ARuntimeMeshActor::ARuntimeMeshActor(const FObjectInitializer& ObjectInitializer
 	, bRunGenerateMeshesOnConstruction(true)
 	, bRunGenerateMeshesOnBeginPlay(false)
 {
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 24
 	SetCanBeDamaged(false);
+#else
+	bCanBeDamaged = false;
+#endif
 
 	RuntimeMeshComponent = CreateDefaultSubobject<URuntimeMeshComponent>(TEXT("RuntimeMeshComponent0"));
 	RuntimeMeshComponent->SetCollisionProfileName(UCollisionProfile::BlockAll_ProfileName);

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshComponent.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshComponent.cpp
@@ -4,7 +4,7 @@
 #include "RuntimeMeshComponentPlugin.h"
 #include "PhysicsEngine/BodySetup.h"
 #include "PhysicsEngine/PhysicsSettings.h"
-#include "Physics/IPhysXCookingModule.h"
+#include "IPhysXCookingModule.h"
 #include "RuntimeMeshCore.h"
 #include "RuntimeMeshGenericVertex.h"
 #include "RuntimeMeshUpdateCommands.h"

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.cpp
@@ -163,7 +163,7 @@ void FRuntimeMeshComponentSceneProxy::GetDynamicMeshElements(const TArray<const 
 			if (ViewFamily.EngineShowFlags.Collision && IsCollisionEnabled() && BodySetup && BodySetup->GetCollisionTraceFlag() != ECollisionTraceFlag::CTF_UseComplexAsSimple)
 			{
 				FTransform GeomTransform(GetLocalToWorld());
-				BodySetup->AggGeom.GetAggGeom(GeomTransform, GetSelectionColor(FColor(157, 149, 223, 255), IsSelected(), IsHovered()).ToFColor(true), NULL, false, false, UseEditorDepthTest(), ViewIndex, Collector);
+				BodySetup->AggGeom.GetAggGeom(GeomTransform, GetSelectionColor(FColor(157, 149, 223, 255), IsSelected(), IsHovered()).ToFColor(true), NULL, false, false, false /*UseEditorDepthTest()*/, ViewIndex, Collector);
 			}
 
 			// Render bounds

--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshLibrary.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshLibrary.cpp
@@ -683,9 +683,9 @@ void URuntimeMeshLibrary::GetStaticMeshSection(UStaticMesh* InMesh, int32 LODInd
 
 				// Lets copy the adjacency information too for tessellation 
 				// At this point all vertices should be copied so it should work to just copy/convert the indices.
-				if (LOD.bHasAdjacencyInfo && LOD.AdjacencyIndexBuffer.GetNumIndices() > 0)
+				if (LOD.bHasAdjacencyInfo && LOD.AdditionalIndexBuffers->AdjacencyIndexBuffer.GetNumIndices() > 0)
 				{
-					FIndexArrayView AdjacencyIndices = LOD.AdjacencyIndexBuffer.GetArrayView();
+					FIndexArrayView AdjacencyIndices = LOD.AdditionalIndexBuffers->AdjacencyIndexBuffer.GetArrayView();
 
 					// We multiply these by 4 as the adjacency data is 12 indices per triangle instead of the normal 3
 					uint32 StartIndex = Section.FirstIndex * 4;


### PR DESCRIPTION
I needed the following changes to be able to compile for 4.24.

Could not find any replacement for `UseEditorDepthTest()` in `RuntimeMeshComponentProxy.cpp`.