### PR TITLE
Fix `AdjacencyTriangles` crash

### DIFF
--- a/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
+++ b/Source/RuntimeMeshComponent/Private/RuntimeMeshStaticMeshConverter.cpp
@@ -132,7 +132,7 @@ bool URuntimeMeshStaticMeshConverter::CopyStaticMeshSectionToRenderableMeshData(
 
 		for (uint32 Index = 0; Index < NumIndices; Index++)
 		{
-			OutMeshData.AdjacencyTriangles.Add(MeshToSectionVertMap[AdjacencyIndices[Index]]);
+			OutMeshData.AdjacencyTriangles.Add(MeshToSectionVertMap[AdjacencyIndices[StartIndex + Index]]);
 		}
 	}
 


### PR DESCRIPTION
Missed offset caused wrong indices for static meshes with 2 and more sections: consequent section vertex indices do not start with 0.

This was tested on commit `78e1cddf9065b23b8200dec5014d98e0abed5a91` and not on v4, but since the code for getting `StaticMesh` sections is the same I am guessing it will also fix the issue on current version. 

Signed-off-by: Denis Maximenko <manlok71@gmail.com>