### PR TITLE
CalculateNormalsTangents fix

### DIFF
--- a/Source/RuntimeMeshComponent/Private/Modifiers/RuntimeMeshModifierNormals.cpp
+++ b/Source/RuntimeMeshComponent/Private/Modifiers/RuntimeMeshModifierNormals.cpp
@@ -191,6 +191,7 @@ void URuntimeMeshModifierNormals::CalculateNormalsTangents(FRuntimeMeshRenderabl
 		TangentX.Normalize();
 		TangentY.Normalize();
 
+		MeshData.Tangents.SetNum(NumVertices, true);
 		MeshData.Tangents.SetNormal(VertxIdx, TangentZ);
 		MeshData.Tangents.SetTangent(VertxIdx, TangentX);
 	}


### PR DESCRIPTION
The method is causing crashes because the size of MeshData.Tangents.Data is zero when SetNormal is called.